### PR TITLE
Replace wrong isd2 import by binf import

### DIFF
--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -78,7 +78,7 @@ else:
     from rexfw.slaves import Slave
     from rexfw.proposers.re import REProposer
 
-    from isd2.samplers.gibbs import GibbsSampler
+    from binf.samplers.gibbs import GibbsSampler
     
     from ensemble_hic.setup_functions import make_posterior, make_subsamplers
     from ensemble_hic.setup_functions import setup_initial_state


### PR DESCRIPTION
I had forgotten to replace an `isd2` import by the appropriate `binf` import in `scripts/run_simulation.py`. This fixes it.